### PR TITLE
add missing -y to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.8
 
 # Install binary packages
-RUN apt-get update && apt-get upgrade
+RUN apt-get update && apt-get upgrade -y
 # Base Dependencies
 RUN apt-get install -y python-tk tk-dev libffi-dev libssl-dev pandoc \
 	libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libmpc-dev \


### PR DESCRIPTION
`docker build -t katana .` will fail if there are updates to do.

```
[13:13 kali@kali docker] (master) > sudo docker build -t katana .
Sending build context to Docker daemon  8.192kB
Step 1/23 : FROM python:3.8
 ---> d47898c6f4b0
Step 2/23 : RUN apt-get update && apt-get upgrade
 ---> Running in 1a0487a3f1fb
Get:1 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [49.3 kB]
Get:4 http://security.debian.org/debian-security buster/updates/main amd64 Packages [187 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7907 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [7380 B]
Fetched 8337 kB in 4s (2136 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages will be upgraded:
  libgnutls-dane0 libgnutls-openssl27 libgnutls28-dev libgnutls30
  libgnutlsxx28
5 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 2859 kB of archives.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
The command '/bin/sh -c apt-get update && apt-get upgrade' returned a non-zero code: 1