### PR TITLE
Added .editorconfig file for global code styling settings.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@
 # top-most EditorConfig file.
 root = true
 
+[**]
 # Unix style newlines prefered.
 end_of_line = lf
 
@@ -16,18 +17,18 @@ insert_final_newline = true
 charset = utf-8
 
 # Use 4 indentations globally except for IML/XML, check next section.
-[!*.{iml,xml}]
+[!**.{iml,xml}]
 indent_size = 4
 
 # IML & XML configuration based on ./.idea/*.iml
-[*.{iml,xml}]
+[**.{iml,xml}]
 indent_size = 2
 indent_style = space
 
 # Use spaces if the file is a python file.
-[*.py]
+[**.py]
 indent_style = space
 
 # Use tabs if the file is NOT a python, IML nor XML file.
-[!*.{py,iml,xml}]
+[!**.{py,iml,xml}]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig file (https://editorconfig.org) is a way to organize
+# the code styling across text editors and IDEs that support it.
+
+# Please use the editorConfig extension provided by your text editor of choice.
+
+# top-most EditorConfig file.
+root = true
+
+# Unix style newlines prefered.
+end_of_line = lf
+
+# Insert a newline at the end of all files
+insert_final_newline = true
+
+# Default character set to UTF-8
+charset = utf-8
+
+# Use 4 indentations globally except for IML/XML, check next section.
+[!*.{iml,xml}]
+indent_size = 4
+
+# IML & XML configuration based on ./.idea/*.iml
+[*.{iml,xml}]
+indent_size = 2
+indent_style = space
+
+# Use spaces if the file is a python file.
+[*.py]
+indent_style = space
+
+# Use tabs if the file is NOT a python, IML nor XML file.
+[!*.{py,iml,xml}]
+indent_style = tab


### PR DESCRIPTION
# The Issue
Other than the specification in CONTRIBUTING.md file there are no ways to check that the submitted code is actually following the standards posed by the project.

# EditorConfig
EditorConfig solves this problem by providing a cross-text-editor auto-formatting that follows the .editorconfig configuration file so basically anyone who uses a text editor with EditorConfig feature (or plugin) can get the specified code formatting.