### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN gem install zsteg
 RUN git clone https://github.com/gleitz/npiet /opt/npiet
 # npiet includes `sys/malloc.h` which doesn't exist. Malloc definitions come
 # from stdlib.h.
-RUN sed -i 's|sys/malloc\.h|stdlib.h|g' /opt/npiet/npiet-foogol.y
+RUN sed -i 's|sys/malloc\.h|stdlib.h|g' /opt/npiet/npiet-foogol.*
 RUN cd /opt/npiet && ./configure && make && make install
 
 # Download jsteg


### PR DESCRIPTION
There was an issue with the npiet tool. npiet includes `sys/malloc.h` which doesn't exist. Malloc definitions come from `stdlib.h`. However, it is only replacing `npiet-foogol.y` and not `npiet-foogol.c`

Without this change, this was the error:

![error](https://user-images.githubusercontent.com/5390120/83695564-9b0dc780-a5fa-11ea-976a-d37443bfe9c6.jpg)
