### PR TITLE
Fixed typo "foremosy" -> "foremost"

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -61,7 +61,7 @@ distribution documentation for further assistance in installing them.
 - jsteg
 - node
 - binwalk
-- foremosy
+- foremost
 - unzip
 - npiet
 - tcpflow


### PR DESCRIPTION
Fixed a typo on the Installation Instructions documentation page.