### PR TITLE
Fix nonce parsing in ctfd provider

### DIFF
--- a/katana/repl/ctfd.py
+++ b/katana/repl/ctfd.py
@@ -23,7 +23,7 @@ class Provider(CTFProvider):
             )
 
         # Parse the nonce
-        nonce = r.text.split('name="nonce" value="')[1].split('"')[0]
+        nonce = r.text.split('name="nonce"')[1].split('value="')[1].split('"')[0]
 
         # Attempt authentication
         r = s.post(


### PR DESCRIPTION
I had this issue.
```
    nonce = r.text.split('name="nonce" value="')[1].split('"')[0]
IndexError: list index out of range
EXCEPTION of type 'IndexError' occurred with message: 'list index out of range'
```
As the order of attributes is not guaranteed, I had another attribute in between name and value.
This fixes it