### PR TITLE
Fix the quipqiup module

### DIFF
--- a/katana/units/crypto/quipqiup.py
+++ b/katana/units/crypto/quipqiup.py
@@ -34,18 +34,26 @@ from katana.units.crypto import CryptoUnit
 
 def decodeSubstitute(cipher: str, time=3, spaces=True) -> str:
     """
-    This is stolen from https://github.com/rallip/substituteBreaker
+    This is based on https://github.com/rallip/substituteBreaker
     All it does is use the ``requests`` module to send the ciphertext to
     quipqiup and returns the results as a string.
     """
-    url = "https://6n9n93nlr5.execute-api.us-east-1.amazonaws.com/prod/solve"
-    clues = ""
-    data = {"ciphertext": cipher, "clues": clues, "solve-spaces": spaces, "time": time}
     headers = {
         "Content-type": "application/x-www-form-urlencoded",
     }
+    
+    clues = ""
+    url = "https://quipqiup.com/solve"
+    data = {"ciphertext":cipher,"clues":clues,"mode":"auto","was_auto":True,"was_clue":False}
 
-    return requests.post(url, data=json.dumps(data), headers=headers).text
+    response = json.loads( requests.post(url, data=json.dumps(data), headers=headers, verify=False).text )
+
+    sleep(response["max_time"])
+    
+    url = "https://quipqiup.com/status"
+    data = {"id":response["id"]}
+
+    return requests.post(url, data=json.dumps(data), headers=headers, verify=False).text
 
 
 class Unit(NotEnglishAndPrintableUnit, CryptoUnit):
@@ -84,7 +92,7 @@ class Unit(NotEnglishAndPrintableUnit, CryptoUnit):
 
         try:
             requests.get(
-                "https://6n9n93nlr5.execute-api.us-east-1.amazonaws.com/prod/solve"
+                "https://quipqiup.com/", verify=False
             )
         except requests.exceptions.ConnectionError:
             raise NotApplicable("cannot reach quipqiup solver")

--- a/katana/units/crypto/quipqiup.py
+++ b/katana/units/crypto/quipqiup.py
@@ -33,7 +33,7 @@ from katana.unit import NotEnglishAndPrintableUnit, NotApplicable
 from katana.units.crypto import CryptoUnit
 
 
-def decodeSubstitute(cipher: str, time=3, spaces=True) -> str:
+def decodeSubstitute(cipher: str, time=3) -> str:
     """
     This is based on https://github.com/rallip/substituteBreaker
     All it does is use the ``requests`` module to send the ciphertext to
@@ -49,7 +49,7 @@ def decodeSubstitute(cipher: str, time=3, spaces=True) -> str:
 
     response = json.loads( requests.post(url, data=json.dumps(data), headers=headers, verify=False).text )
 
-    sleep(response["max_time"])
+    sleep( min(response["max_time"], time) )
     
     url = "https://quipqiup.com/status"
     data = {"id":response["id"]}

--- a/katana/units/crypto/quipqiup.py
+++ b/katana/units/crypto/quipqiup.py
@@ -27,6 +27,7 @@ import json  # json is used for communicating with quipqiup.com
 import requests
 import io
 from typing import Any
+from time import sleep
 
 from katana.unit import NotEnglishAndPrintableUnit, NotApplicable
 from katana.units.crypto import CryptoUnit


### PR DESCRIPTION
Fix issue #27 by using the actual quipqiup site as the existing api always returns a 500 (Internal Server Error) response code.

It works, but I don't like having to set the `verify=False` with requests as this stops certificate validation which makes it less secure.
I also dislike using `sleep()`, but I can't think of a better way to wait for the server.