### PR TITLE
Default flag-format

### DIFF
--- a/katana/repl/__init__.py
+++ b/katana/repl/__init__.py
@@ -343,6 +343,14 @@ class Repl(cmd2.Cmd):
         # Register hook to update prompt
         self.register_cmdfinalization_hook(self.finalization_hook)
 
+        # Set a default flag-format if none supplied
+        if self.manager.flag_pattern is None:
+            flag_format = "S+{.*?}"
+            self.manager.set("manager", "flag-format", flag_format)
+            self.poutput(
+                f"[{Fore.BLUE}+{Style.RESET_ALL}] Using default flag-format `{flag_format}`"
+            )
+
         # Start the manager
         self.manager.start()
 


### PR DESCRIPTION
This checks to see if any flag-format has been provided and instead of failing with an exception, sets a standard default format of `S+{.*?}`.  Prints a message to the user that it's using a default flag format.

This allows you to just run `$ katana` after install without any configuration errors / issues, bringing you to the prompt where you could set the flag-format if you need to, rather than requiring it from the command arg or ini.