### PR TITLE
Use supported version of libenchant package to fix Docker build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ image: ubuntu:18.04
 pages:
     script:
     - apt-get update
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y python3.7-tk tk-dev python3.7 python3-pip python3-setuptools python3.7-dev python3.7-venv libffi-dev libssl-dev pandoc libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libenchant-dev git
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y python3.7-tk tk-dev python3.7 python3-pip python3-setuptools python3.7-dev python3.7-venv libffi-dev libssl-dev pandoc libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libenchant-2-dev git
     - python3.7 setup.py install
     - export TERM=linux && export TERMINFO=/etc/terminfo && make -C docs html
     - mv ./docs/build/html public

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ virtual environment.
 sudo apt update
 sudo apt-get install -y python-tk tk-dev libffi-dev libssl-dev pandoc \
 	libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libmpc-dev \
-	libdbus-glib-1-dev ruby libenchant-dev apktool nodejs groff binwalk \
+	libdbus-glib-1-dev ruby libenchant-2-dev apktool nodejs groff binwalk \
 	foremost tcpflow poppler-utils exiftool steghide stegsnow bison ffmpeg \
 	libgd-dev less
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
 	&& apt-get install -y -qq python-tk tk-dev libffi-dev libssl-dev pandoc \
 	libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libmpc-dev \
-	libdbus-glib-1-dev ruby libenchant-dev apktool nodejs groff binwalk \
+	libdbus-glib-1-dev ruby libenchant-2-dev apktool nodejs groff binwalk \
 	foremost tcpflow poppler-utils exiftool steghide stegsnow bison ffmpeg \
 	libgd-dev less \
 	# Clean up for smaller images


### PR DESCRIPTION
As it was already raised in this issue https://github.com/JohnHammond/katana/issues/42, the existing package `libenchant-dev` is making the build of the docker image to fail.
![error_build](https://user-images.githubusercontent.com/23425100/142784342-606af2bc-cb29-414f-90f0-650d47b52077.PNG)

It seems not to be supported anymore and instead, we should use `libenchant-2-dev` package. With this update, docker image build is successful.
![katana_pr](https://user-images.githubusercontent.com/23425100/142784344-b8bc009b-de57-47c3-a734-08a23bfeb953.PNG)

I have also updated the references to the package in the `README` and `gitlab_ci`, as trying to install it with `apt-get` fails too.
![image](https://user-images.githubusercontent.com/23425100/142784336-dedcb4bc-fba4-4039-9ae9-fc85eeef890e.png)
