### PR TITLE
fix for cmd2 API change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ sphinx
 sphinx-rtd-theme
 gmpy
 git+https://github.com/elliptic-shiho/primefac-fork#egg=primefac
-cmd2
+cmd2==1.5.0
 watchdog
 regex
 dbus-python


### PR DESCRIPTION
Changes in `cmd2` API break the init script, these changes happened at `2.0`, specify using the last version `1.5` to temperately fix this.

Issue caused:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/katana/katana/__main__.py", line 10, in <module>
    from katana.repl import Repl, ReplMonitor
  File "/katana/katana/repl/__init__.py", line 301, in <module>
    class Repl(cmd2.Cmd):
  File "/katana/katana/repl/__init__.py", line 587, in Repl
    monitor_remove_parser.add_argument(
  File "/usr/local/lib/python3.8/site-packages/cmd2/argparse_custom.py", line 866, in _add_argument_wrapper
    new_arg = orig_actions_container_add_argument(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/argparse.py", line 1368, in add_argument
    action = action_class(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'choices_method'
```

> Replaced `choices_function` / `choices_method` with `choices_provider`.

https://github.com/python-cmd2/cmd2/blob/master/CHANGELOG.md#200-june-6-2021