### PR TITLE
Addressing issues with the Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
 	&& apt-get install -y -qq python-tk tk-dev libffi-dev libssl-dev pandoc \
 	libgmp3-dev libzbar-dev tesseract-ocr xsel libpoppler-cpp-dev libmpc-dev \
-	libdbus-glib-1-dev ruby libenchant-2-dev apktool nodejs groff binwalk \
+	libdbus-glib-1-dev ruby ruby-dev libenchant-2-dev apktool nodejs groff binwalk \
 	foremost tcpflow poppler-utils exiftool steghide stegsnow bison ffmpeg \
 	libgd-dev less \
 	# Clean up for smaller images

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,20 @@ RUN cp /usr/snow-20130616/snow /usr/local/bin/snow && chmod +x /usr/local/bin/sn
 RUN git clone --recursive https://github.com/JohnHammond/katana.git /katana
 # Install katana python dependencies
 WORKDIR /katana
+# Unfortunately, since we clone this I can't make a change directly and had to path with SED. 
+# I could have changed the clone to a Copy of this project, but that would require moving the Dockerfile
+# up a directory (due to security concerns Docker cannot build anything above its build context)
+# Arguably a Copy makes more sense as the Clone makes testing local changes harder.
+# So to make it explicit, I'd recommend 
+# 1. Moving the Dockerfile up a directory
+# 2. Removing the Cloning
+# 3. COPYing the local folder
+	# COPY . /katana
+# 4. Updating the path of the COPY that occurs like 15 lines down
+	# COPY ./docker/katana.sh /start.sh
+
+RUN sed -i "s/cmd2=='1.0.1'/cmd2==1.0.1/" requirements.txt
+
 RUN pip install -r requirements.txt
 
 # Create runtime data directory directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ sphinx
 sphinx-rtd-theme
 gmpy
 git+https://github.com/elliptic-shiho/primefac-fork#egg=primefac
-cmd2=='1.0.1'
+cmd2==1.0.1
 watchdog
 regex
 dbus-python


### PR DESCRIPTION
Hi John,
Big fan of the YouTube channel. I tried building Katana and ran into some errors. I see you recently updated things and I'm assuming it built for you. I'm guessing your build-cache might have had something to do with that. Not sure how my build could fail while yours succeeded. I built using `docker build --no-cache -t kitana .`. 

Each commit details the error encountered. Should be able to replicate using the above command. The second one was a bit messier because you were Cloning the GIT repo (which obviously I don't control). You probably want to just take the change of dropping the commas from the version.