### PR TITLE
fix versioned dependency in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ sphinx
 sphinx-rtd-theme
 gmpy
 git+https://github.com/elliptic-shiho/primefac-fork#egg=primefac
-cmd2=='1.0.1'
+cmd2==1.0.1
 watchdog
 regex
 dbus-python


### PR DESCRIPTION
I was trying to install `katana` on Archlinux,  in a virtual Python en-
vironment, and noticed the following.

`pip install -r requirements.txt` fails with the following message :

```
ERROR: Could not find a version that satisfies the requirement
cmd2=='1.0.1' (from versions: 0.6.0.py3, 0.1, 0.2, 0.2.1, 0.2.2, 0.2.3,
0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.4.1, 0.3.5, 0.3.6, 0.3.7, 0.4,
0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.4.6, 0.4.7, 0.4.8, 0.5.0, 0.5.1,
0.5.2, 0.5.3, 0.5.4, 0.5.5, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4, 0.6.5,
0.6.5.1, 0.6.6, 0.6.6.1, 0.6.7, 0.6.8, 0.6.9, 0.7.0, 0.7.1, 0.7.2,
0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.7.9, 0.8.0, 0.8.1, 0.8.2,
0.8.3, 0.8.4, 0.8.5, 0.8.6, 0.8.6.1, 0.8.7rc1, 0.8.7, 0.8.8, 0.8.9,
0.9.0.1, 0.9.1, 0.9.2, 0.9.3, 0.9.4, 0.9.5, 0.9.6, 0.9.7, 0.9.8, 0.9.9,
0.9.10, 0.9.11, 0.9.12, 0.9.13, 0.9.14, 0.9.15, 0.9.16, 0.9.17, 0.9.18,
0.9.19, 0.9.20, 0.9.21, 0.9.22, 0.9.23, 0.9.24, 0.9.25, 0.10.0, 0.10.1,
1.0.0, 1.0.1, 1.0.2, 1.1.0, 1.2.0, 1.2.1, 1.3.0, 1.3.1, 1.3.2, 1.3.3,
1.3.4, 1.3.5, 1.3.6, 1.3.7, 1.3.8, 1.3.9, 1.3.10, 1.3.11, 1.4.0, 1.5.0,
2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3,
2.4.0, 2.4.1)
ERROR: No matching distribution found for cmd2=='1.0.1'
```

This is caused by the single quotes; removing those fixes the issue.
